### PR TITLE
Fix: Allow 7 or 8 digits for DNI in filename regex

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ setInterval(() => {
 				let dni = file.split('_')[2];
 				let regexlaboratorio = /^[0-9]{4}$/;
 				const regexProtocolo = /^[0-9]{1,8}$/;
-				let regexdni = /^[0-9]{8}$/;
+				let regexdni = /^[0-9]{7,8}$/;
 				if (regexlaboratorio.test(laboratorio) && regexProtocolo.test(protocolo) && regexdni.test(dni)) {
 					try {
 						let filetosend = fs.readFileSync(`${config.ruta}/${file}`, 'base64');


### PR DESCRIPTION
The DNI validation regex in `server.js` was updated to accept both 7 and 8 digit numbers.

The previous regex `^[0-9]{8}$` only allowed for 8-digit DNIs. The new regex `^[0-9]{7,8}$` correctly validates DNIs that are either 7 or 8 digits long.

Manual testing confirmed that:
- Files with 7-digit DNIs in the name are processed.
- Files with 8-digit DNIs in the name are processed.
- Files with DNI lengths other than 7 or 8 (e.g., 6 or 9 digits) are correctly identified as invalid and not processed.